### PR TITLE
Refactor account-related methods and DTOs

### DIFF
--- a/CarCare.Apis.Controllers/Controllers/Account/AccountController.cs
+++ b/CarCare.Apis.Controllers/Controllers/Account/AccountController.cs
@@ -105,10 +105,10 @@ namespace CarCare.Apis.Controllers.Controllers.Account
 		#region Confirmation
 
 
-		[HttpPost("ForgetPasswordEmail")]
-		public async Task<ActionResult> ForgetPasswordEmail(ForgetPasswordByEmailDto forgetPasswordDto)
+		[HttpPost("SendCodeByEmail")]
+		public async Task<ActionResult<SuccessDto>> SendCodeByEmail(SendCodeByEmailDto forgetPasswordDto)
 		{
-			var result = await serviceManager.AuthService.ForgetPasswordByEmailasync(forgetPasswordDto);
+			var result = await serviceManager.AuthService.SendCodeByEmailasync(forgetPasswordDto);
 			return Ok(result);
 		}
 
@@ -120,7 +120,7 @@ namespace CarCare.Apis.Controllers.Controllers.Account
 		}
 
 		[HttpPost("VerfiyCodeEmail")]
-		public async Task<ActionResult> VerfiyCodeEmail(ResetCodeConfirmationByEmailDto resetCode)
+		public async Task<ActionResult<SuccessDto>> VerfiyCodeEmail(ResetCodeConfirmationByEmailDto resetCode)
 		{
 			var result = await serviceManager.AuthService.VerifyCodeByEmailAsync(resetCode);
 			return Ok(result);
@@ -134,7 +134,7 @@ namespace CarCare.Apis.Controllers.Controllers.Account
 		}
 
 		[HttpPut("ResetPasswordEmail")]
-		public async Task<ActionResult> ResetPasswordEmail(ResetPasswordByEmailDto resetPassword)
+		public async Task<ActionResult<UserDto>> ResetPasswordEmail(ResetPasswordByEmailDto resetPassword)
 		{
 			var result = await serviceManager.AuthService.ResetPasswordByEmailAsync(resetPassword);
 			return Ok(result);
@@ -147,23 +147,9 @@ namespace CarCare.Apis.Controllers.Controllers.Account
 			return Ok(result);
 		}
 
-		[HttpPost("ConfirmationCodeEmail")]
-		public async Task<ActionResult> ConfirmationCodeEmail(ForgetPasswordByEmailDto confirmationCode)
-		{
-			var result = await serviceManager.AuthService.ConfirmationCodeSendByEmailAsync(confirmationCode);
-			return Ok(result);
-		}
-
-
-		[HttpPost("ConfirmationCodePhone")]
-		public async Task<ActionResult> ConfirmationCodePhone(ForgetPasswordByPhoneDto confirmationCode)
-		{
-			var result = await serviceManager.AuthService.ConfirmationCodeSendByPhoneAsync(confirmationCode);
-			return Ok(result);
-		}
 
 		[HttpPost("ConfirmEmail")]
-		public async Task<ActionResult> ConfirmEmail(ConfirmationEmailCodeDto codeDto)
+		public async Task<ActionResult<SuccessDto>> ConfirmEmail(ConfirmationEmailCodeDto codeDto)
 		{
 			var result = await serviceManager.AuthService.ConfirmEmailAsync(codeDto);
 			return Ok(result);

--- a/CarCare.Application/Services/Auth/AuthService.cs
+++ b/CarCare.Application/Services/Auth/AuthService.cs
@@ -193,8 +193,8 @@ namespace CarCare.Core.Application.Services.Auth
 			if (!result.Succeeded)
 				throw new ValidationExeption() { Errors = result.Errors.Select(E => E.Description) };
 
-			var email = new ForgetPasswordByEmailDto() { Email = user.Email };
-			await ConfirmationCodeSendByEmailAsync(email);
+			var email = new SendCodeByEmailDto() { Email = user.Email };
+			await SendCodeByEmailasync(email);
 
 
 			var roleResult = await userManager.AddToRoleAsync(user, Types.User.ToString());
@@ -255,8 +255,8 @@ namespace CarCare.Core.Application.Services.Auth
 			if (!result.Succeeded)
 				throw new ValidationExeption() { Errors = result.Errors.Select(E => E.Description) };
 
-			var email = new ForgetPasswordByEmailDto() { Email = tech.Email };
-			await ConfirmationCodeSendByEmailAsync(email);
+			var email = new SendCodeByEmailDto() { Email = tech.Email };
+			await SendCodeByEmailasync(email);
 
 
 
@@ -1005,7 +1005,7 @@ namespace CarCare.Core.Application.Services.Auth
 
 		#region Confirmation
 
-		public async Task<SuccessDto> ForgetPasswordByEmailasync(ForgetPasswordByEmailDto emailDto)
+		public async Task<SuccessDto> SendCodeByEmailasync(SendCodeByEmailDto emailDto)
 		{
 			var user = await userManager.Users.Where(u => u.Email == emailDto.Email).FirstOrDefaultAsync();
 
@@ -1178,21 +1178,6 @@ namespace CarCare.Core.Application.Services.Auth
 			};
 
 			return mappedUser;
-		}
-
-
-		public async Task<SuccessDto> ConfirmationCodeSendByEmailAsync(ForgetPasswordByEmailDto emailDto)
-		{
-			var result = await ForgetPasswordByEmailasync(emailDto);
-
-			return result;
-		}
-
-		public async Task<SuccessDto> ConfirmationCodeSendByPhoneAsync(ForgetPasswordByPhoneDto phoneDto)
-		{
-			var result = await ForgetPasswordByPhoneAsync(phoneDto);
-
-			return result;
 		}
 
 

--- a/CareCare.Application.Abstraction/Models/Auth/ForgetPasswordByEmailDtos/ResetCodeConfirmationByEmailDto.cs
+++ b/CareCare.Application.Abstraction/Models/Auth/ForgetPasswordByEmailDtos/ResetCodeConfirmationByEmailDto.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace CareCare.Core.Application.Abstraction.Models.Auth.ForgetPasswordByEmailDtos
 {
-	public class ResetCodeConfirmationByEmailDto : ForgetPasswordByEmailDto
+	public class ResetCodeConfirmationByEmailDto : SendCodeByEmailDto
 	{
 		[Required]
 		public required int ResetCode { get; set; }

--- a/CareCare.Application.Abstraction/Models/Auth/ForgetPasswordByEmailDtos/ResetPasswordByEmailDto.cs
+++ b/CareCare.Application.Abstraction/Models/Auth/ForgetPasswordByEmailDtos/ResetPasswordByEmailDto.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace CareCare.Core.Application.Abstraction.Models.Auth.ForgetPasswordByEmailDtos
 {
-	public class ResetPasswordByEmailDto : ForgetPasswordByEmailDto
+	public class ResetPasswordByEmailDto : SendCodeByEmailDto
 	{
 		[Required]
 		public required string NewPassword { get; set; }

--- a/CareCare.Application.Abstraction/Models/Auth/ForgetPasswordByEmailDtos/SendCodeByEmailDto.cs
+++ b/CareCare.Application.Abstraction/Models/Auth/ForgetPasswordByEmailDtos/SendCodeByEmailDto.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace CareCare.Core.Application.Abstraction.Models.Auth.ForgetPasswordByEmailDtos
 {
-	public class ForgetPasswordByEmailDto
+	public class SendCodeByEmailDto
 	{
 		[Required]
 		public required string Email { get; set; }

--- a/CareCare.Application.Abstraction/Services/Auth/IAuthService.cs
+++ b/CareCare.Application.Abstraction/Services/Auth/IAuthService.cs
@@ -75,7 +75,7 @@ namespace CareCare.Core.Application.Abstraction.Services.Auth
 
 		#region Confirmation (Email - Phone)
 
-		Task<SuccessDto> ForgetPasswordByEmailasync(ForgetPasswordByEmailDto emailDto);
+		Task<SuccessDto> SendCodeByEmailasync(SendCodeByEmailDto emailDto);
 
 		Task<SuccessDto> ForgetPasswordByPhoneAsync(ForgetPasswordByPhoneDto forgetPasswordDto);
 
@@ -86,11 +86,6 @@ namespace CareCare.Core.Application.Abstraction.Services.Auth
 		Task<UserDto> ResetPasswordByEmailAsync(ResetPasswordByEmailDto resetCodeDto);
 
 		Task<UserDto> ResetPasswordByPhoneAsync(ResetPasswordByPhoneDto resetPasswordDto);
-
-
-		Task<SuccessDto> ConfirmationCodeSendByEmailAsync(ForgetPasswordByEmailDto confirmationCodeDto);
-
-		Task<SuccessDto> ConfirmationCodeSendByPhoneAsync(ForgetPasswordByPhoneDto confirmationCodeDto);
 
 		Task<SuccessDto> ConfirmEmailAsync(ConfirmationEmailCodeDto codeDto);
 

--- a/CareCare.Application.Abstraction/Validators/Auth/LoginValidator.cs
+++ b/CareCare.Application.Abstraction/Validators/Auth/LoginValidator.cs
@@ -18,10 +18,6 @@ namespace CareCare.Core.Application.Abstraction.Validators.Auth
 				.WithMessage("PhoneNumber Must Not Empty , Plz Add a {PropertyName}")
 				.Matches(RegexPatterns.PhoneNumber).WithMessage("Invalid Egyptian phone number.");
 
-			RuleFor(x => x.Password)
-							.NotEmpty()
-							.WithMessage("\"Password Must Not Empty ,Plz Add a {PropertyName}\"")
-							.Matches(RegexPatterns.Password).WithMessage("Password must be at least 8 characters long and contain at least one digit.");
 		}
 	}
 }


### PR DESCRIPTION
- Renamed `ForgetPasswordEmail` to `SendCodeByEmail` in `AccountController.cs`, updated return type to `ActionResult<SuccessDto>`, and changed the method call to `SendCodeByEmailasync`.
- Removed `ConfirmationCodeEmail` and `ConfirmationCodePhone` End Points
- Removed `ConfirmationCodeSendByEmailAsync` and `ConfirmationCodeSendByPhoneAsync` methods.